### PR TITLE
:bug: Explicit node version 16 and update org references

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - run: yarn install
     - run: yarn build
     - run: yarn lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build with:
-# docker build --tag issa-diallo/mynotif-frontend .
+# docker build --tag mynotif/mynotif-frontend .
 # Run with:
-# docker run --rm -it --publish 3000:80 issa-diallo/mynotif-frontend
+# docker run --rm -it --publish 3000:80 mynotif/mynotif-frontend
 # Or interactive shell:
-# docker run -it --rm issa-diallo/mynotif-frontend sh
+# docker run -it --rm mynotif/mynotif-frontend sh
 FROM node:16-alpine as build
 
 # Specify where our app will live in the container

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # MyNotif Frontend
 
-[![Tests](https://github.com/issa-diallo/mynotif_frontend/actions/workflows/tests.yml/badge.svg)](https://github.com/issa-diallo/mynotif_frontend/actions/workflows/tests.yml)
+[![Tests](https://github.com/mynotif/mynotif_frontend/actions/workflows/tests.yml/badge.svg)](https://github.com/mynotif/mynotif_frontend/actions/workflows/tests.yml)
 
 Frontend for MyNotif: Patient management app for nurses.
 - https://mynotif.vercel.app/
 
 Backend is available via:
-<https://github.com/issa-diallo/Mynotif_backend>
+<https://github.com/mynotif/mynotif-frontend>
 
 ## Install
 ```sh
@@ -28,9 +28,9 @@ yarn lint
 ## Docker
 Build:
 ```sh
-docker build --tag issa-diallo/mynotif-frontend .
+docker build --tag mynotif/mynotif-frontend .
 ```
 Run:
 ```sh
-docker run --rm -it --publish 3000:80 issa-diallo/mynotif-frontend
+docker run --rm -it --publish 3000:80 mynotif/mynotif-frontend
 ```

--- a/package.json
+++ b/package.json
@@ -35,11 +35,15 @@
     "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "docker-build": "docker build --tag issa-diallo/mynotif-frontend .",
-    "docker-run": "docker run --rm -it --publish 3000:80 issa-diallo/mynotif-frontend",
+    "docker:build": "docker build --tag mynotif/mynotif-frontend .",
+    "docker:run": "docker run --rm -it --publish 3000:80 mynotif/mynotif-frontend",
     "lint": "ts-standard src/",
     "format": "ts-standard --fix src/",
     "eject": "react-scripts eject"
+  },
+  "engines" : {
+    "npm" : ">=8.0.0 <9.0.0",
+    "node" : ">=16.0.0 <17.0.0"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Fixes the `ERR_OSSL_EVP_UNSUPPORTED` error.