### PR TITLE
:bug: Fix external links for admin redirection

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,7 +19,7 @@ const Footer = (): JSX.Element => {
         {useIsLoggedIn() === true && (
           <>
             {profile.is_staff && (
-              <FooterNav url={`${BACKEND_URL}/admin`} icon='user-shield' title={t('text.admin')} />
+              <FooterNav url={`${BACKEND_URL}/admin`} icon='user-shield' title={t('text.admin')} isExternal />
             )}
             <FooterNav url='/home' icon='house' title={t('text.home')} />
             <FooterNav url='/patients' icon='users' title={t('text.patients')} />

--- a/src/components/FooterNav.tsx
+++ b/src/components/FooterNav.tsx
@@ -7,19 +7,31 @@ interface FooterNavProps {
   url: string
   icon: IconName
   title: string
+  isExternal?: boolean
 }
 
-const FooterNav = ({ url, icon, title }: FooterNavProps): JSX.Element => {
+const FooterNav = ({ url, icon, title, isExternal = false }: FooterNavProps): JSX.Element => {
   const location = useLocation()
   const highlightOnPathname = (pathname: string): string => location.pathname === pathname ? 'text-primary' : ''
+
+  const linkContent = (
+    <div className={`d-flex flex-column align-items-center ${highlightOnPathname(url)}`}>
+      <FontAwesomeIcon icon={['fas', icon]} className='fa-lg' />
+      <div className='mt-1'>{title}</div>
+    </div>
+  )
+
   return (
     <Nav className='me-auto'>
-      <Nav.Link as={Link} to={url}>
-        <div className={`d-flex flex-column align-items-center ${highlightOnPathname(url)}`}>
-          <FontAwesomeIcon icon={['fas', icon]} className='fa-lg' />
-          <div className='mt-1'>{title}</div>
-        </div>
-      </Nav.Link>
+      {isExternal ? (
+        <Nav.Link as='a' href={url} target='_blank' rel='noopener noreferrer'>
+          {linkContent}
+        </Nav.Link>
+      ) : (
+        <Nav.Link as={Link} to={url}>
+          {linkContent}
+        </Nav.Link>
+      )}
     </Nav>
   )
 }


### PR DESCRIPTION
This commit introduces the ability to handle external URLs in the FooterNav component, allowing for both internal navigation within the PWA and external redirections. A new prop `isExternal` has been added to differentiate between internal and external links. This enhancement fixes the issue where the admin link was incorrectly concatenated, leading to navigation errors.