### PR TITLE
:bug: Fix allows i18next to automatically recognize

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,9 +12,10 @@ i18n
   // init i18next
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
-    debug: true,
+    debug: false,
     fallbackLng: 'fr',
     supportedLngs: ['en', 'fr'], // *** added this ***
+    nonExplicitSupportedLngs: true,
     interpolation: {
       escapeValue: false // not needed for react as it escapes by default
     },


### PR DESCRIPTION
This allows your application to respond more flexibly to user language preferences. For example, a user with a browser configured for fr-CA (Canadian French) will be automatically redirected to the standard French translations.