### PR TITLE
:sparkles: Upgrade react-onesignal and refactor OneSignalManager component

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.51.4",
     "react-i18next": "^13.0.1",
-    "react-onesignal": "^2.0.4",
+    "react-onesignal": "^3.0.1",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
     "serve": "^12.0.0",

--- a/public/OneSignalSDKWorker.js
+++ b/public/OneSignalSDKWorker.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+importScripts("https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,9 +36,9 @@ function App (): JSX.Element {
   return (
     <div className='App bg-light'>
       <BrowserRouter>
-        <OneSignalManager>
-          <TokenContextProvider>
-            <ProfileContextProvider>
+        <TokenContextProvider>
+          <ProfileContextProvider>
+            <OneSignalManager>
               <FlashMessageContextProvider>
                 <Header />
                 <Container className='mb-5 pb-5'>
@@ -85,9 +85,9 @@ function App (): JSX.Element {
                 </Container>
                 <Footer />
               </FlashMessageContextProvider>
-            </ProfileContextProvider>
-          </TokenContextProvider>
-        </OneSignalManager>
+            </OneSignalManager>
+          </ProfileContextProvider>
+        </TokenContextProvider>
       </BrowserRouter>
     </div>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,9 +6,9 @@ import reportWebVitals from './reportWebVitals'
 import './i18n'
 
 ReactDOM.render(
-  <React.StrictMode>
+  <>
     <App />
-  </React.StrictMode>,
+  </>,
   document.getElementById('root')
 )
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,7 +4,9 @@ import {
   Prescription,
   PrescriptionUploadResponse,
   Profile,
-  Token
+  Token,
+  OneSignal,
+  SubscriptionInfo
 } from '../types'
 import { BACKEND_URL } from './constants'
 
@@ -156,6 +158,21 @@ const updateUser = async (token: string, data: Profile): Promise<Profile> => {
   return response.data
 }
 
+const createOneSignalSubscriptionId = async (token: string, subscriptionId: string): Promise<{}> => {
+  const url = BACKEND_URL + '/onesignal/'
+  const headers = { Authorization: `Token ${token}` }
+  const data = { subscription_id: subscriptionId }
+  const response = await axios.post<OneSignal>(url, data, { headers })
+  return response.data
+}
+
+const getOneSignalSubscriptionId = async (token: string): Promise<SubscriptionInfo[]> => {
+  const url = BACKEND_URL + '/onesignal/'
+  const headers = { Authorization: `Token ${token}` }
+  const response = await axios.get<SubscriptionInfo[]>(url, { headers })
+  return response.data
+}
+
 export {
   getPatients,
   getPatient,
@@ -173,5 +190,7 @@ export {
   deletePatient,
   createPrescription,
   resetPassword,
-  confirmResetPassword
+  confirmResetPassword,
+  createOneSignalSubscriptionId,
+  getOneSignalSubscriptionId
 }

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-const BACKEND_URL: string = process.env.REACT_APP_BACKEND_URL ?? 'http://localhost:8000'
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL ?? 'http://localhost:8000'
 assert(typeof BACKEND_URL === 'string')
 
 const USER_DATE_FORMAT = 'dd/MM/yyyy'

--- a/src/services/oneSignal/OneSignalManager.tsx
+++ b/src/services/oneSignal/OneSignalManager.tsx
@@ -1,21 +1,44 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
+import { strict as assert } from 'assert'
 import OneSignal from 'react-onesignal'
+import { ProfileContext } from '../../context/profile'
+import { TokenContext } from '../../context/token'
+import { createOneSignalSubscriptionId, getOneSignalSubscriptionId } from '../api'
 
-const OneSignalManager: React.FC = ({ children }) => {
+const OneSignalManager: React.FC<any> = ({ children }) => {
+  const { profile } = useContext(ProfileContext)
+  const { token } = useContext(TokenContext)
+  const [oneSignalInitialized, setOneSignalInitialized] = useState<boolean>(false)
+
   useEffect(() => {
+    if (profile.id === 0 || token == null || token.trim() === '' || oneSignalInitialized) return
+
     const initializeOneSignal = async (): Promise<void> => {
+      const result = await getOneSignalSubscriptionId(token)
+      if (result.length > 0) return
+
+      await OneSignal.init({
+        appId: process.env.REACT_APP_ONE_SIGNAL_ID as string,
+        safari_web_id: process.env.REACT_APP_SAFARI_WEB_ID as string,
+        allowLocalhostAsSecureOrigin: true,
+        notifyButton: { enable: true },
+        size: 'small'
+      })
+
+      setOneSignalInitialized(true)
+
       try {
-        await OneSignal.init({
-          appId: process.env.REACT_APP_ONE_SIGNAL_ID as string,
-          allowLocalhostAsSecureOrigin: true
-        })
+        await OneSignal.login(profile.id.toString())
+        const subscriptionId = (window.OneSignal?.User as any).onesignalId
+        assert(subscriptionId, 'Subscription ID is not defined')
+        await createOneSignalSubscriptionId(token, subscriptionId)
       } catch (error) {
-        console.error('Error initializing OneSignal:', error)
+        console.error('Error creating subscription ID', error)
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    initializeOneSignal()
-  }, [])
+    // eslint-disable-next-line no-void
+    void initializeOneSignal()
+  }, [profile.id, oneSignalInitialized, token])
 
   return <>{children}</>
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,15 @@ interface Patient {
   prescriptions: Prescription[]
 }
 
+interface OneSignal {
+  subscription_id: string
+}
+
+interface SubscriptionInfo {
+  subscription_id: string
+  user: number
+}
+
 const defaultPatient = {
   id: 0,
   firstname: '',
@@ -81,7 +90,9 @@ export type {
   PrescriptionUploadResponse,
   Profile,
   Token,
-  RegisterFormType
+  RegisterFormType,
+  OneSignal,
+  SubscriptionInfo
 }
 
 export { defaultPatient, defaultPrescription }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9812,10 +9812,10 @@ react-onclickoutside@^6.12.2:
   resolved "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz"
   integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
-react-onesignal@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-onesignal/-/react-onesignal-2.0.4.tgz#d3bf7e4ff4c176b542ff4a2fa2a67a899dbb5472"
-  integrity sha512-llZ4PV1+EsWWZDt0BRils6gAxaxMoYP0Z3rlNivQy4xqUaiO1/PcRaIJ6CuzCci/koDsw5IzLOXEHlV4Yn+d9Q==
+react-onesignal@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-onesignal/-/react-onesignal-3.0.1.tgz#055cc4f80cf0d58328c8febef6ca08242ed76620"
+  integrity sha512-AfAtGdXRcuMhVf+9OXehGcQeiJIYl1ihAByvfVNa3RCA1Vnn19tBha4XQB+o3ukUh2IQn0yiflRO4vXgI9nOng==
 
 react-popper@^2.2.5, react-popper@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
    - Update the react-onesignal package from version 2.0.4 to 3.0.1
    - Integrate state and context management in OneSignalManager
    - Implement createSubscriptionIdOneSignal function to manage subscription IDs through the OneSignal API.
    - Adjust App component structure for better context encapsulation.
    - Add OneSignal type definitions
    - Remove StrictMode from ReactDOM.render to simplify the rendering process.