### PR TITLE
:bug: Fix badge color display issue for expiring prescriptions

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -47,7 +47,7 @@ const getIconClass = (prescription: Prescription): string => {
     return COLOR_STATUS.WARNING
   }
 
-  if (prescription.is_valid) {
+  if (prescription.is_valid && !prescription.expiring_soon) {
     return COLOR_STATUS.SUCCESS
   }
 


### PR DESCRIPTION
This commit addresses an issue where the badge color remains green even when the prescription is set to expire within the next 7 days. The condition has been updated to ensure that the badge color accurately reflects the expiration status of the prescription.