### PR TITLE
:lipstick: Customize Logo on Start Page

### DIFF
--- a/src/components/HeaderProfile.tsx
+++ b/src/components/HeaderProfile.tsx
@@ -1,9 +1,9 @@
-import { Logo } from './module/Logo'
+import LogoPng from "./module/LogoPng"
 
 const HeaderProfile: React.FC = () => {
   return (
     <div className=''>
-      <Logo size={50} />
+      <LogoPng size={150} />
     </div>
   )
 }

--- a/src/components/module/LogoPng.tsx
+++ b/src/components/module/LogoPng.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import clsx from "clsx"
 
-
 interface LogoPngProps {
     src?: string;
     alt?: string;
     size?: number | string;
     className?: string;
+    fontSize?: number;
 }
 
 const LogoPng: React.FC<LogoPngProps> = ({
     src = "/ordopro/logo-cote.png",
     alt = "logo ordopro",
     size = 60,
-    className,
+    className = "",
+    fontSize = "100px",
 }) => {
+    const style = {
+        width: size,
+        fontSize: fontSize
+      }
     return (
-        <div className={clsx(className, `w-${size} h-auto w-24 mx-auto mb-4 ${className}`)}>
+        <div className={clsx(className, `my-4 ${className}`)}
+            style={ style }
+        >
             <img src={src} alt={alt} />
         </div>
     );


### PR DESCRIPTION
- Replace logo component with LogoPng in HeaderProfile
- Increase logo size to 150px
- Improve flexibility of LogoPng component with props for size and font
- Customize style for better rendering and positioning