### PR TITLE
:sparkles: Handle file name overflow

### DIFF
--- a/src/components/forms/PrescriptionForm.tsx
+++ b/src/components/forms/PrescriptionForm.tsx
@@ -135,7 +135,11 @@ const PrescriptionForm: FunctionComponent<PrescriptionFormProps> = ({
     })
 
     if (files !== null && files !== undefined) {
-      setFile(files[0])
+      const { name, type } = files[0]
+      const extension = name.split('.').pop()
+      const newName = `ordonnance_${Date.now()}.${extension}`
+      const newFile = new File([files[0]], newName, { type })
+      setFile(newFile)
     }
   }
 


### PR DESCRIPTION
- Updated PrescriptionForm to generate a unique file name for uploaded prescription photos to avoid overflow issues.