### PR TITLE
:sparkles: Display days remaining until end date fix 283

### DIFF
--- a/src/components/prescriptions/PrescriptionCard.tsx
+++ b/src/components/prescriptions/PrescriptionCard.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useNavigate } from 'react-router-dom'
 import { Prescription } from '../../types'
 import { getIconClass } from '../../utils/helpers'
+import { useDaysRemaining } from '../../hook/daysRemaining'
 
 interface PrescriptionCardProps {
   doctorName: string
@@ -12,6 +13,7 @@ interface PrescriptionCardProps {
 
 export const PrescriptionCard = ({ doctorName, endDate, patientName, prescription }: PrescriptionCardProps): JSX.Element => {
   const navigate = useNavigate()
+  const daysRemaining = useDaysRemaining(endDate)
 
   const goToPrescription = (): void => {
     navigate(`/prescriptions/${prescription.id}`)
@@ -31,10 +33,12 @@ export const PrescriptionCard = ({ doctorName, endDate, patientName, prescriptio
         </div>
         <div className='flex items-center mb-2'>
           <p className='flex-grow font-semibold'>End of prescription: </p>
-          <div className={`flex items-center ${isValidIconClass} px-3 py-1 rounded-full`}>
-            <FontAwesomeIcon icon={['fas', 'calendar']} className='mr-2' />
-            <span>{endDate}</span>
-          </div>
+            <div className={`flex items-center ${isValidIconClass} px-3 py-1 rounded-full`}>
+              <FontAwesomeIcon icon={['fas', 'calendar']} className='mr-2' />
+                <span>
+                  {daysRemaining <= 0 ? endDate : `${daysRemaining} jour${daysRemaining > 1 ? 's' : ''} restant${daysRemaining > 1 ? 's' : ''}`}
+                </span>
+            </div>
         </div>
         <div className='mb-2'>
           <p className='font-semibold'>Patient: <span className='font-normal'>{patientName}</span></p>

--- a/src/hook/daysRemaining.ts
+++ b/src/hook/daysRemaining.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+
+export const useDaysRemaining = (endDate: string): number => {
+  return useMemo(() => {
+    const today = new Date();
+    const [day, month, year] = endDate.split('/').map(Number);
+    const end = new Date(year, month - 1, day);
+
+    const diffTime = end.getTime() - today.setHours(0, 0, 0, 0);
+    const daysRemaining = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    return daysRemaining;
+  }, [endDate]);
+}


### PR DESCRIPTION
- Add custom hook useDaysRemaining to calculate remaining days
- Display remaining days instead of end date when prescription is active
- Handle pluralization for "jour(s)" and "restant(s)"