### PR TITLE
:sparkles: simplify patient name handling in prescriptions page

### DIFF
--- a/src/pages/prescriptions/PrescriptionsPage.tsx
+++ b/src/pages/prescriptions/PrescriptionsPage.tsx
@@ -1,12 +1,9 @@
+import { useCallback, useState } from 'react'
 import usePrescription from '../../hook/prescription.hook'
-import { useCallback, useContext, useEffect, useState } from 'react'
 import SearchBar from '../../components/SearchBar'
 import { PrescriptionCard } from '../../components/prescriptions/PrescriptionCard'
-import { getPatient } from '../../services/api'
-import assert from 'assert'
-import { Patient, Prescription } from '../../types'
+import { Prescription } from '../../types'
 import useTranslationHook from '../../hook/TranslationHook'
-import { TokenContext } from '../../context/token'
 import { formatDate } from '../../utils/helpers'
 import { Container } from '../../components/home/Container'
 import { Loading } from '../../components/loading/Loading'
@@ -14,119 +11,61 @@ import PrescriptionFilter from '../../components/PrescriptionFilter'
 
 const PrescriptionsPage = (): JSX.Element => {
   const [prescriptions] = usePrescription()
-
   const { t } = useTranslationHook()
-  const { token } = useContext(TokenContext)
 
   const [filteredPrescriptions, setFilteredPrescriptions] = useState<Prescription[]>(prescriptions)
-  const [searchPatient, setSearchPatient] = useState<string>('')
-
-  // Using Record to get a key-value array
-  const [patients, setPatients] = useState<Record<number, Patient>>({})
 
   // Function to check if the prescription's doctor name matches the search
-  const isDoctorMatch = (prescription: Prescription, searchValue: string): boolean => {
+  const isDoctorMatch = (prescription: Prescription, search: string): boolean => {
     const doctorName = prescription.prescribing_doctor.toLowerCase()
-    const searchLowerCase = searchValue.toLowerCase()
+    const searchLowerCase = search.toLowerCase()
     return doctorName.includes(searchLowerCase)
   }
 
   // Function to check if the prescription's patient name matches the search
-  const isPatientMatch = (prescription: Prescription, searchValue: string): boolean => {
-    const patient = patients[prescription.id]
-    assert(patient)
-    const patientFullName = getPatientFullName(patient).toLowerCase()
-    const searchLowerCase = searchValue.toLowerCase()
+  const isPatientMatch = (prescription: Prescription, search: string): boolean => {
+    const patientFullName = `${prescription.patient_firstname} ${prescription.patient_lastname}`.toLowerCase()
+    const searchLowerCase = search.toLowerCase()
     return patientFullName.includes(searchLowerCase)
   }
 
-  // Utility function to get the full name of a patient
-  const getPatientFullName = (patient: Patient): string => {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (!patient) return ''
-    assert(patient)
-    const { firstname, lastname } = patient
-    return `${firstname} ${lastname}`
-  }
-
-  const updatePatientsData = (prevPatients: Record<number, Patient>, patientResults: Array<{ id: number, patient: Patient }>): Record<number, Patient> =>
-    patientResults.reduce((newPatientsData, { id, patient }) => (
-      { ...newPatientsData, [id]: patient })
-      , { ...prevPatients })
-
-  const filterByPrescriptions = useCallback((prescription: Prescription, searchValue: string) => (
-    isDoctorMatch(prescription, searchValue) ||
-    isPatientMatch(prescription, searchValue)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  ), [patients])
-
-  useEffect(() => {
-    const fetchPatients = async (): Promise<void> => {
-      assert(token)
-      try {
-        // Create a promise for each prescription
-        const patientPromises = prescriptions.map(async (prescription) => {
-          const patientData = await getPatient(token, prescription.patient)
-          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          if (!patientData) throw new Error('Patient data is missing')
-          // Returns an object with patient data and prescription id
-          return { id: prescription.id, patient: patientData }
-        })
-        // Waits for patientPromises to be loaded
-        const patientResults = await Promise.all(patientPromises)
-
-        setPatients(prevPatients => {
-          return updatePatientsData(prevPatients, patientResults)
-        })
-
-        const filteredData = prescriptions.filter((prescription) =>
-          filterByPrescriptions(prescription, searchPatient)
-        )
-        setFilteredPrescriptions(filteredData)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-
-    // eslint-disable-next-line no-void
-    void fetchPatients()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, prescriptions])
+  const filterByPrescriptions = useCallback((prescription: Prescription, search: string) => (
+    isDoctorMatch(prescription, search) ||
+    isPatientMatch(prescription, search)
+  ), [])
 
   /**
    * Manages the search by filtering prescriptions according to the value entered by the user.
    */
-  const handleSearch = useCallback((searchValue: string) => {
-    const filteredData = prescriptions.filter((prescription) => filterByPrescriptions(prescription, searchValue))
+  const handleSearch = useCallback((search: string) => {
+    const filteredData = prescriptions.filter((prescription) =>
+      filterByPrescriptions(prescription, search)
+    )
     setFilteredPrescriptions(filteredData)
-    setSearchPatient(searchValue)
   }, [prescriptions, filterByPrescriptions])
 
+  if (!prescriptions) {
+    return <Loading />
+  }
+
   return (
-    <>
-      {filteredPrescriptions && patients ?
-        (
-          <Container>
-            <SearchBar onSearch={handleSearch} placeholderText={t('text.searchDoctor')} />
-            <PrescriptionFilter prescriptions={prescriptions} onFilterChanged={setFilteredPrescriptions} />
-            {
-              filteredPrescriptions.map((prescription) => (
-                <PrescriptionCard
-                  key={prescription.id}
-                  doctorName={prescription.prescribing_doctor}
-                  endDate={formatDate(prescription.end_date)}
-                  patientName={getPatientFullName(patients[prescription.id])}
-                  prescription={prescription}
-                />
-              ))
-            }
-            <div className='h-20' /> {/* Added space for the bottom */}
-          </Container>
-        ) : (
-          <Loading />
-        )
-      }
-    </>
+    <Container>
+      <SearchBar onSearch={handleSearch} placeholderText={t('text.searchDoctor')} />
+      <PrescriptionFilter
+        prescriptions={prescriptions}
+        onFilterChanged={setFilteredPrescriptions}
+      />
+      {filteredPrescriptions.map((prescription) => (
+        <PrescriptionCard
+          key={prescription.id}
+          doctorName={prescription.prescribing_doctor}
+          endDate={formatDate(prescription.end_date)}
+          patientName={`${prescription.patient_firstname} ${prescription.patient_lastname}`}
+          prescription={prescription}
+        />
+      ))}
+      <div className='h-20' /> {/* Added space for the bottom */}
+    </Container>
   )
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,8 @@ interface Prescription {
   photo_prescription: string
   is_valid: boolean
   patient: number
+  patient_firstname: string
+  patient_lastname: string
   expiring_soon: boolean
 }
 
@@ -58,6 +60,8 @@ const defaultPrescription = {
   photo_prescription: '',
   is_valid: false,
   patient: 0,
+  patient_firstname: '',
+  patient_lastname: '',
   expiring_soon: false
 }
 

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -17,6 +17,8 @@ describe('helpers', () => {
       photo_prescription: '',
       is_valid: true,
       patient: 1,
+      patient_firstname: '',
+      patient_lastname: '',
       email_doctor: '',
       expiring_soon: true
     }
@@ -28,6 +30,8 @@ describe('helpers', () => {
       photo_prescription: '',
       is_valid: true,
       patient: 2,
+      patient_firstname: '',
+      patient_lastname: '',
       email_doctor: '',
       expiring_soon: false
     }
@@ -39,6 +43,8 @@ describe('helpers', () => {
       photo_prescription: '',
       is_valid: false,
       patient: 3,
+      patient_firstname: '',
+      patient_lastname: '',
       email_doctor: '',
       expiring_soon: false
     }
@@ -63,7 +69,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 2,
@@ -76,7 +84,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       }
     ]
     expect(getValidPrescription(prescriptions)).toEqual(prescriptions[0])
@@ -95,7 +105,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       }
     ]
     expect(getValidPrescription(prescriptions)).toEqual(null)
@@ -114,7 +126,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 2,
@@ -127,7 +141,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 3,
@@ -140,7 +156,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       }
     ]
     expect(getLastPrescription(prescriptions)).toEqual(prescriptions[1])
@@ -164,7 +182,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 2,
@@ -177,7 +197,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 3,
@@ -190,7 +212,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       }
     ]
     expect(getValidOrLastPrescription(prescriptions)).toEqual(prescriptions[2])
@@ -209,7 +233,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 2,
@@ -222,7 +248,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       },
       {
         id: 3,
@@ -235,7 +263,9 @@ describe('helpers', () => {
         email_doctor: '',
         expiring_soon: false,
         photo_prescription: '',
-        patient: 1
+        patient: 1,
+        patient_firstname: '',
+        patient_lastname: '',
       }
     ]
     expect(getValidOrLastPrescription(prescriptions)).toEqual(prescriptions[1])


### PR DESCRIPTION
- Remove getPatient API call and patient data loading logic
- Add patient_firstname and patient_lastname fields to Prescription type
- Use patient name fields directly in PrescriptionsPage component
- Clean up unused imports and simplify code