### PR TITLE
:sparkles: Refactor RegisterForm to remove username field

### DIFF
--- a/src/components/forms/RegisterForm.tsx
+++ b/src/components/forms/RegisterForm.tsx
@@ -20,15 +20,14 @@ const RegisterForm = (): JSX.Element => {
 
   const handleRegister = async (data: RegisterFormType): Promise<void> => {
     setLoading(true)
-    const { username, password, email } = data
+    const { password, email } = data
     try {
-      await createUser(username, password, email)
+      await createUser( password, email)
       navigate('/login')
       addSuccessMessage({ body: t('text.userRegister') })
     } catch (error: any) {
       if (error.response?.status === 400) {
         setError('password', { message: t('error.invalidCredentials') })
-        setError('username', { message: t('error.invalidCredentials') })
         setError('email', { message: t('error.invalidCredentials') })
       }
       setLoading(false)
@@ -37,16 +36,6 @@ const RegisterForm = (): JSX.Element => {
 
   return (
     <form className='w-9/12 mt-1 p-1 space-y-4 ' onSubmit={handleSubmit(handleRegister)}>
-      <InputFieldContainer icon={['fas', 'user']}>
-      <Input
-          type='text'
-          register={register}
-          id='username'
-          placeholder="Nom d'utilisateur"
-          disabled={loading}
-        />
-      </InputFieldContainer>
-      <FormFieldError errorMessage={errors.username?.message} />
       <InputFieldContainer icon={['fas', 'envelope']}>
       <Input
         type='email'

--- a/src/components/forms/validations/ValidationRegister.ts
+++ b/src/components/forms/validations/ValidationRegister.ts
@@ -4,28 +4,6 @@ import { Resolver } from 'react-hook-form'
 
 export const resolver: Resolver<RegisterFormType> = async (values) => {
     const errors: Record<string, any> = {};
-    if (!values.username) {
-      errors.username = {
-        type: "required",
-        message: t('error.requiredUsername'),
-      };
-    } else if (values.username.length < 3) {
-      errors.username = {
-        type: "minLength",
-        message: t('error.minLengthError'),
-      };
-    } else if (values.username.length > 20) {
-        errors.username = {
-            type: "maxLength",
-            message: t('error.maxLength'),
-        };
-    } else if (!/^[a-zA-Z0-9_]*$/.test(values.username)) {
-        errors.username = {
-            type: "pattern",
-            message: t('error.invalidCharacters'),
-        };
-    }
-
     if (!values.email) {
       errors.email = {
         type: "required",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -8,7 +8,7 @@ import {
   OneSignal,
   SubscriptionInfo,
 } from '../types'
-import { API_V1 } from './constants'
+import { API_V1, API_V2 } from './constants'
 
 const getPatients = async (token: string, fields?: string[]): Promise<Patient[]> => {
   const url = API_V1 + '/patient/'
@@ -128,9 +128,9 @@ const login = async (username: string, password: string): Promise<Token> => {
   return response.data
 }
 
-const register = async (username: string, password: string, email: string): Promise<{}> => {
-  const data = { username, password, email }
-  const url = API_V1 + '/account/register'
+const register = async ( password: string, email: string): Promise<{}> => {
+  const data = { password, email }
+  const url = API_V2 + '/account/register'
   const response = await axios.post(url, data)
   return response.data
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,6 @@ interface ErrorResponse {
 }
 
 interface RegisterFormType {
-  username: string
   email: string
   password: string
 }


### PR DESCRIPTION
- Removed `username` field from RegisterForm component to simplify the registration process.

- Updated validation rules in `ValidationRegister.ts` to exclude username validation.

- Modified the `register` API method to accept only `password` and `email` parameters,
updating the API endpoint to `API_V2`.

- Adjusted the `RegisterFormType` interface to remove the `username` property.