### PR TITLE
:sparkles: Remove username field from profile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,9 +15,8 @@ const Header = (): JSX.Element => {
   const location = useLocation()
   const state = location.state as LocationState
   const { profile } = useContext(ProfileContext)
-  const initialUsername = profile.username.charAt(0).toUpperCase() + profile.username.charAt(1).toUpperCase()
   const initialFullname = profile.first_name.charAt(0).toUpperCase() + profile.last_name.charAt(0).toUpperCase()
-  const initials = initialFullname !== '' ? initialFullname : initialUsername
+  const initials = initialFullname ? initialFullname : ''
   const isPatientProfileMatch = location.pathname.match(/^\/patients\/\d+\/?$/)
   const isPrescriptionProfileMatch = location.pathname.match(/^\/prescriptions\/\d+\/?$/)
   const isLoggedIn = useIsLoggedIn()

--- a/src/components/forms/ProfileForm.tsx
+++ b/src/components/forms/ProfileForm.tsx
@@ -29,8 +29,7 @@ export const ProfileForm = ({ profile, addErrorMessageCallback }: ProfileFormPro
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    if (profile.username !== '') {
-      setValue('username', profile.username)
+    if (profile.email !== '') {
       setValue('email', profile.email)
       setValue('first_name', profile.first_name)
       setValue('last_name', profile.last_name)
@@ -48,7 +47,6 @@ export const ProfileForm = ({ profile, addErrorMessageCallback }: ProfileFormPro
       if (error.response?.status === 400) {
         setError('last_name', { message: t('error.invalidCredentials') })
         setError('first_name', { message: t('error.invalidCredentials') })
-        setError('username', { message: t('error.invalidCredentials') })
         setError('email', { message: t('error.invalidCredentials') })
       }
       setLoading(false)
@@ -59,16 +57,6 @@ export const ProfileForm = ({ profile, addErrorMessageCallback }: ProfileFormPro
     <Container>
       <div className='bg-gray-50 min-h-screen flex flex-col'>
         <form className='space-y-4 ' onSubmit={handleSubmit(handleProfile)}>
-          <InputFieldContainer icon={['fas', 'lock']} disabled>
-            <Input
-              type='text'
-              register={register}
-              id='username'
-              placeholder="Nom d'utilisateur"
-              disabled={true}
-            />
-          </InputFieldContainer>
-          <FormFieldError errorMessage={errors.username?.message} />
           <InputFieldContainer icon={['fas', 'envelope']}>
             <Input
               type='email'

--- a/src/components/forms/validations/ValidationProfile.ts
+++ b/src/components/forms/validations/ValidationProfile.ts
@@ -4,28 +4,6 @@ import { Resolver } from 'react-hook-form'
 
 export const resolver: Resolver<Profile> = async (values) => {
     const errors: Record<string, any> = {};
-    if (!values.username) {
-      errors.username = {
-        type: "required",
-        message: t('error.requiredUsername'),
-      };
-    } else if (values.username.length < 3) {
-      errors.username = {
-        type: "minLength",
-        message: t('error.minLengthError'),
-      };
-    } else if (values.username.length > 20) {
-        errors.username = {
-            type: "maxLength",
-            message: t('error.maxLength'),
-        };
-    } else if (!/^[a-zA-Z0-9_]*$/.test(values.username)) {
-        errors.username = {
-            type: "pattern",
-            message: t('error.invalidCharacters'),
-        };
-    }
-
     if (!values.email) {
       errors.email = {
         type: "required",

--- a/src/pages/profile/ProfileDetail.tsx
+++ b/src/pages/profile/ProfileDetail.tsx
@@ -16,18 +16,16 @@ const ProfileDetail = (): JSX.Element => {
     navigate('/profile/edit')
   }
 
-  const initials = (profile?.username?.charAt(0) ?? '').toUpperCase() + (profile?.username?.charAt(1) ?? '').toUpperCase()
-  const fullName = `${profile?.username ?? ''}`
+  const initials = (profile?.first_name?.charAt(0) ?? '').toUpperCase() + (profile?.last_name?.charAt(0) ?? '').toUpperCase()
+  const fullName = `${profile?.email ?? ''}`
 
   return (
     <>
       {profile !== null ? (
         <Container className=''>
           <BannerDetail fullName={fullName} initials={initials} onEditClick={onEdit} />
-          <CardDetail icon={['fas', 'user']} content={profile.username} defaultContent='Pseudo manquant' title={t('form.userName')} />
           <CardDetail icon={['fas', 'address-card']} content={profile.first_name} defaultContent='Prénom manquant' title={t('form.firstName')} />
           <CardDetail icon={['fas', 'address-card']} content={profile.last_name} defaultContent='Nom manquant' title={t('form.lastName')} />
-          <CardDetail icon={['fas', 'envelope']} content={profile.email} defaultContent='Email manquant' title={t('form.emailAddress')} />
         </Container>
       ) : (
         <div className='flex justify-center items-center min-h-screen'>

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -23,7 +23,7 @@ const ProfileEdit = (): JSX.Element => {
 
   return (
     <>
-      {profile?.username !== '' && (
+      {profile?.email !== '' && (
         <>
           <ProfileForm addErrorMessageCallback={addErrorMessageCallback} profile={profile} />
         </>

--- a/src/pages/setting/AccountPage.tsx
+++ b/src/pages/setting/AccountPage.tsx
@@ -10,7 +10,7 @@ import useTranslationHook from '../../hook/TranslationHook'
 export const AccountPage = (): JSX.Element => {
   const { profile } = useContext(ProfileContext)
   const initials = (profile?.first_name?.charAt(0) ?? '').toUpperCase() + (profile?.last_name?.charAt(0) ?? '').toUpperCase()
-  const fullName = `${profile?.username ?? ''}`
+  const fullName = `${profile?.email ?? ''}`
   const navigate = useNavigate()
   const logout = useLogout()
   const onLogoutClick = (e: React.MouseEvent<HTMLElement>): void => logout()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,7 +68,6 @@ const defaultPrescription = {
 interface Profile {
   id: number
   email: string
-  username: string
   first_name: string
   last_name: string
   is_staff: boolean


### PR DESCRIPTION
- Removed the `username` field from the `Profile`.
- Updated `Header`, `ProfileForm`, `ProfileDetail`, `ProfileEdit`, and `AccountPage` components to reflect this change.

- Adjusted display logic for initials and user information to utilize `first_name`, `last_name`, and `email` instead of `username`.

- Removed `ValidationProfile` validation rules related to `username`.