### PR TITLE
:recycle: Simplify ProfileEdit

### DIFF
--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -21,15 +21,7 @@ const ProfileEdit = (): JSX.Element => {
     []
   )
 
-  return (
-    <>
-      {profile?.email !== '' && (
-        <>
-          <ProfileForm addErrorMessageCallback={addErrorMessageCallback} profile={profile} />
-        </>
-      )}
-    </>
-  )
+  return <ProfileForm addErrorMessageCallback={addErrorMessageCallback} profile={profile} />
 }
 
 export default ProfileEdit


### PR DESCRIPTION
There's no reason to check for the profile not to be empty before rendering the form. The profile can be filled asynchronously after the form is rendered this isn't a problem.
Also remove the unnecessary fragments.